### PR TITLE
Django 2.0 removed the psycopg2_version attribute

### DIFF
--- a/django_postgrespool2/base.py
+++ b/django_postgrespool2/base.py
@@ -128,7 +128,7 @@ class DatabaseWrapper(Psycopg2DatabaseWrapper):
     def _set_autocommit(self, autocommit):
         # fix autocommit setting not working in proxied connection
         with self.wrap_database_errors:
-            if self.psycopg2_version >= (2, 4, 2):
+            if not hasattr(self, 'psycopg2_version') or self.psycopg2_version >= (2, 4, 2):
                 self.connection.connection.autocommit = autocommit
             else:
                 if autocommit:


### PR DESCRIPTION
This commit (https://github.com/django/django/commit/690fc30d4426549a7b419e4104449bb2f2226697#diff-aef216ccdc37941bfed98ea3c80f7642) removed the psycopg2_version attribute. Django also bumped the minimum version requirement for psycopg2 so if the attribute does not exist we can be sure the version is recent.