### PR TITLE
Ensure no transactions are active before autocommit

### DIFF
--- a/django_postgrespool2/base.py
+++ b/django_postgrespool2/base.py
@@ -129,6 +129,8 @@ class DatabaseWrapper(Psycopg2DatabaseWrapper):
         # fix autocommit setting not working in proxied connection
         with self.wrap_database_errors:
             if not hasattr(self, 'psycopg2_version') or self.psycopg2_version >= (2, 4, 2):
+                if self.connection.connection.get_transaction_status() == psycopg2.extensions.TRANSACTION_STATUS_INTRANS:
+                    self.connection.connection.rollback()                
                 self.connection.connection.autocommit = autocommit
             else:
                 if autocommit:


### PR DESCRIPTION
When using the "pre_ping" option on the pool creation sqlalchemy does an initial "select()" before the connection is returned to us. Therefore a transaction is in progress and we cannot set autocommit.

This does a rollback() when a transaction is detected.

Addresses https://github.com/lcd1232/django-postgrespool2/issues/3