### PR TITLE
Fixed error when composing __version__ which happens installing from zip file

### DIFF
--- a/django_postgrespool2/__init__.py
+++ b/django_postgrespool2/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 version = (0, 1, 0)
-__version__ = '.'.join(version)
+__version__ = '.'.join(str(n) for n in version)
 author = 'lcd1232'


### PR DESCRIPTION
This was happening when installing from zip file:

```
Processing ./requirements/packages/django-postgrespool2.zip
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/pc/389q2ms16nsg71v_tbzm7y4h0000gn/T/pip-fqr8270w-build/setup.py", line 4, in <module>
        from django_postgrespool2 import __version__, __author__
      File "/private/var/folders/pc/389q2ms16nsg71v_tbzm7y4h0000gn/T/pip-fqr8270w-build/django_postgrespool2/__init__.py", line 3, in <module>
        __version__ = '.'.join(version)
    TypeError: sequence item 0: expected str instance, int found
```