### PR TITLE
use raw connection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,11 @@ install:
 
 script:
   - tox -e $TOXENV
-service:
-  - postgresql
+addons:
+  postgresql: "10"
+  apt:
+    packages:
+    - postgresql-10
+    - postgresql-client-10
 before_script:
   - psql -c 'create database postgrespool_test;' -U postgres

--- a/django_postgrespool2/base.py
+++ b/django_postgrespool2/base.py
@@ -93,6 +93,8 @@ class DatabaseWrapper(Psycopg2DatabaseWrapper):
 
     def _close(self):
         if self._pool_connection is not None:
+            if not self.is_usable():
+                self._pool_connection.invalidate()
             with self.wrap_database_errors:
                 return self._pool_connection.close()
 
@@ -140,7 +142,6 @@ class DatabaseWrapper(Psycopg2DatabaseWrapper):
         return c
 
     def is_usable(self):
-        # https://github.com/kennethreitz/django-postgrespool/issues/24
-        if self._pool_connection is None:
+        if not self.connection:
             return False
-        return self._pool_connection.is_valid
+        return self.connection.closed == 0

--- a/django_postgrespool2/base.py
+++ b/django_postgrespool2/base.py
@@ -13,23 +13,23 @@ if 'Psycopg2DatabaseWrapper' not in globals():
         # Django >= 1.9
         from django.db.backends.postgresql.base import (
             psycopg2,
-            PSYCOPG2_VERSION,
             Database,
             DatabaseWrapper as Psycopg2DatabaseWrapper,
         )
         from django.db.backends.postgresql.creation import (
             DatabaseCreation as Psycopg2DatabaseCreation,
         )
+        from django.db.backends.postgresql.utils import utc_tzinfo_factory
     except ImportError:
         from django.db.backends.postgresql_psycopg2.base import (
             psycopg2,
             Database,
-            PSYCOPG2_VERSION,
             DatabaseWrapper as Psycopg2DatabaseWrapper,
         )
         from django.db.backends.postgresql_psycopg2.creation import (
             DatabaseCreation as Psycopg2DatabaseCreation,
         )
+        from django.db.backends.postgresql_psycopg2.utils import utc_tzinfo_factory
 
 
 # DATABASE_POOL_ARGS should be something like:
@@ -49,13 +49,6 @@ log = logging.getLogger('z.pool')
 
 def _log(message, *args):
     log.debug(message)
-
-
-@event.listens_for(pool_cls, 'connect')
-def receive_connect(dbapi_conn, conn_record):
-    # psycopg 2.8 add connection info thus assign connection record info to it
-    if PSYCOPG2_VERSION >= (2, 8, 0):
-        conn_record.info = dbapi_conn.info
 
 
 # Only hook up the listeners if we are in debug mode.
@@ -85,21 +78,28 @@ class DatabaseWrapper(Psycopg2DatabaseWrapper):
         super(DatabaseWrapper, self).__init__(*args, **kwargs)
         self._pool = pool_cls(
             lambda: get_conn(**self.get_connection_params()), **pool_args)
+        self._pool_connection = None
         self.creation = DatabaseCreation(self)
 
     @property
     def pool(self):
         return self._pool
 
-    def _commit(self):
-        if self.connection is not None and self.is_usable():
+    def _close(self):
+        if self._pool_connection is not None:
             with self.wrap_database_errors:
-                return self.connection.commit()
+                return self._pool_connection.close()
 
-    def _rollback(self):
-        if self.connection is not None and self.is_usable():
-            with self.wrap_database_errors:
-                return self.connection.rollback()
+    def create_cursor(self, name=None):
+        if name:
+            # In autocommit mode, the cursor will be used outside of a
+            # transaction, hence use a holdable cursor.
+            cursor = self._pool_connection.cursor(
+                name, scrollable=False, withhold=self.connection.autocommit)
+        else:
+            cursor = self._pool_connection.cursor()
+        cursor.tzinfo_factory = utc_tzinfo_factory if settings.USE_TZ else None
+        return cursor
 
     def dispose(self):
         """Dispose of the pool for this instance, closing all connections."""
@@ -108,24 +108,23 @@ class DatabaseWrapper(Psycopg2DatabaseWrapper):
 
     def get_new_connection(self, conn_params):
         # get new connection through pool, not creating a new one outside.
-        c = self.pool.connect()
+        self._pool_connection = self.pool.connect()
+        c = self._pool_connection.connection  # dbapi connection
 
         options = self.settings_dict['OPTIONS']
         try:
             self.isolation_level = options['isolation_level']
         except KeyError:
-            self.isolation_level = c.connection.isolation_level
+            self.isolation_level = c.isolation_level
         else:
             # Set the isolation level to the value from OPTIONS.
-            if self.isolation_level != c.connection.isolation_level:
-                c.connection.set_session(isolation_level=self.isolation_level)
+            if self.isolation_level != c.isolation_level:
+                c.set_session(isolation_level=self.isolation_level)
 
         return c
 
-    def _set_autocommit(self, autocommit):
-        with self.wrap_database_errors:
-            self.connection.connection.autocommit = autocommit
-
     def is_usable(self):
         # https://github.com/kennethreitz/django-postgrespool/issues/24
-        return self.connection.is_valid
+        if self._pool_connection is None:
+            return False
+        return self._pool_connection.is_valid

--- a/django_postgrespool2/base.py
+++ b/django_postgrespool2/base.py
@@ -64,6 +64,16 @@ def get_conn(**kw):
 
 
 class DatabaseCreation(Psycopg2DatabaseCreation):
+    def _clone_test_db(self, *args, **kw):
+        self.connection.dispose()
+        super(DatabaseCreation, self)._clone_test_db(*args, **kw)
+
+    def create_test_db(self, *args, **kw):
+        """Ensure connection pool is disposed before trying to create database.
+        """
+        self.connection.dispose()
+        super(DatabaseCreation, self).create_test_db(*args, **kw)
+
     def destroy_test_db(self, *args, **kw):
         """Ensure connection pool is disposed before trying to drop database.
         """

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from setuptools import setup
+from setuptools import setup, find_packages
 from django_postgrespool2 import __version__, __author__
 
 required = [
@@ -16,7 +16,7 @@ setup(
     author=__author__,
     author_email='malexey1984@gmail.com',
     url='https://github.com/lcd1232/django-postgrespool2',
-    packages=['django_postgrespool2'],
+    packages=find_packages(),
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     install_requires=required,
     license='MIT',


### PR DESCRIPTION
Turn out recent sqlalchemy version not work with current implement of psycopg2 connection info support, so in this patch I switch connection to raw dbapi connection instead of sqlalchemy wrapper connection.

This patch also fixes travis build and packaging which does not include postgis support.