### PR TITLE
FIX : for Django 2.x and 3.x if settings.USE_TZ is True, the tzinfo M…

### DIFF
--- a/django_postgrespool2/base.py
+++ b/django_postgrespool2/base.py
@@ -98,7 +98,7 @@ class DatabaseWrapper(Psycopg2DatabaseWrapper):
                 name, scrollable=False, withhold=self.connection.autocommit)
         else:
             cursor = self._pool_connection.cursor()
-        cursor.tzinfo_factory = utc_tzinfo_factory if settings.USE_TZ else None
+        cursor.tzinfo_factory = self.tzinfo_factory if settings.USE_TZ else None
         return cursor
 
     def tzinfo_factory(self, offset):


### PR DESCRIPTION
Hi @lcd1232,

I faced the same kind of issue as described in #22. 
The link between my issue and the database connection pool was not straightforward. It took me a while to figure out why a timezone aware timestamp stored in DB loses the TZ info when loaded into a DateTimeField attribute.

My app is running under Django 3.x and the current code of django-postgresqlpool2 is quite close to be compatible.
This PR should fix the issue.

I saw your PR #27 that was never merged, I hope this one will eventually be.

Thanx in advance.
Thierry
