### PR TITLE
Disable psycopg2 parsing JSONField value on Django 3.1+

### DIFF
--- a/django_postgrespool2/base.py
+++ b/django_postgrespool2/base.py
@@ -11,6 +11,7 @@ from django.db.backends.postgresql.base import (
 )
 from django.db.backends.postgresql.creation import DatabaseCreation as Psycopg2DatabaseCreation
 from django.dispatch import Signal
+from django.utils import version
 try:
     from django.utils.asyncio import async_unsafe
 except ImportError:
@@ -54,6 +55,7 @@ pool_disposed = Signal()
 
 log = logging.getLogger('z.pool')
 
+django_version = version.get_version_tuple(version.get_version())
 
 def _log(message, *args):
     log.debug(message)
@@ -152,6 +154,8 @@ class DatabaseWrapper(Psycopg2DatabaseWrapper):
             if self.isolation_level != c.isolation_level:
                 c.set_session(isolation_level=self.isolation_level)
 
+        if django_version >= (3, 1, 1):
+            psycopg2.extras.register_default_jsonb(conn_or_curs=c, loads=lambda x: x)
         return c
 
     def is_usable(self):

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,8 +1,14 @@
 from django.db import models
 from django.utils import timezone
 
+try:
+    from django.db.models import JSONField
+except ImportError:
+    from django.contrib.postgres.fields import JSONField
+
 
 class DogModel(models.Model):
 
     name = models.CharField(max_length=200)
     created = models.DateTimeField(default=timezone.now)
+    attrs = JSONField(default=dict)

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -15,3 +15,8 @@ class TestPool(TestCase):
         self.assertEqual(dog.created.tzname(), "UTC")
         dog = DogModel.objects.get(name="wow")
         self.assertEqual(dog.created.tzname(), "UTC")
+
+    def test_with_json(self):
+        DogModel.objects.create(name="wow", attrs={"color": "pink"})
+        dog = DogModel.objects.get(name="wow")
+        self.assertEqual(dog.attrs, {"color": "pink"})


### PR DESCRIPTION
Fixes #25; related change in Django project https://github.com/django/django/pull/13358